### PR TITLE
fully annotated Op04n08c

### DIFF
--- a/MS3/op04n08c.mscx
+++ b/MS3/op04n08c.mscx
@@ -1517,7 +1517,7 @@
         <voice>
           <Harmony>
             <harmonyType>1</harmonyType>
-            <name>IVM7–ii65(2)</name>
+            <name>IVM7-ii65(2)</name>
             </Harmony>
           <Chord>
             <durationType>eighth</durationType>


### PR DESCRIPTION
I used the guidelines we established in op04n08b for this movement (V/III instead of VII, and IVM7–ii65(2) in m8.1).

mm11.1/15.1 were a bit tricky—the whole first beat can be analyzed with ii instead of iv (iiº6(42)–ii%43–iv7). I am fine with either one. I also think it could be further simplified if we ignore the inversion on 11.1.2/15.1.2

